### PR TITLE
Remove submodule and adjust build system.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "adapter"]
-	path = adapter
-	url = https://github.com/eclipse-cdt/cdt-gdb-adapter

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -9,3 +9,4 @@ README.md
 src
 tsconfig.json
 webpack.config.js
+*.code-workspace

--- a/README.md
+++ b/README.md
@@ -6,12 +6,16 @@ It will also implement IDE side support for any debug adapter protocol extension
 
 ## Building
 
-For now, we have the debug adapter as a submodule. This allows us to work on and test both at the same time. Once things mature, we'll switch to pull the adapter out of npm as a proper dependency.
+Do an ```npm install``` to fetch the dependencies.
 
-The build uses webpack. We duplicate the debug adapter build and add in the vscode extension build resulting in two bundles, gdbDebugAdapter.js and extension.js.
+The extension currently depends on having the cdt-gdb-adapter available in source form in one of these places and checks in this order.
+- Location pointed to by ```CDT_ADAPTER_DIR``` environment variable
+- From sibling directory ```../cdt-gdb-adapter```
+- The github npm dependency in ```node_modules/cdt-gdb-adapter```
+
+After that, the build is pretty simple. It uses webpack to bundle the extension and the adapter into the ```out``` directory.
 
 ```
-npm install
 npm run build
 ```
 

--- a/cdt-gdb.code-workspace
+++ b/cdt-gdb.code-workspace
@@ -1,0 +1,11 @@
+{
+	"folders": [
+		{
+			"path": "."
+		},
+		{
+			"path": "../cdt-gdb-adapter"
+		}
+	],
+	"settings": {}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -759,7 +759,7 @@
       "dev": true
     },
     "cdt-gdb-adapter": {
-      "version": "github:eclipse-cdt/cdt-gdb-adapter#a3c8cbf1d356d5c1a78490cdd02d424f5e5282c9",
+      "version": "github:eclipse-cdt/cdt-gdb-adapter#fee803e47b05c3ee580946a629cba863a7a45633",
       "from": "github:eclipse-cdt/cdt-gdb-adapter",
       "requires": {
         "vscode-debugadapter": "^1.32.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -758,6 +758,13 @@
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
     },
+    "cdt-gdb-adapter": {
+      "version": "github:eclipse-cdt/cdt-gdb-adapter#a3c8cbf1d356d5c1a78490cdd02d424f5e5282c9",
+      "from": "github:eclipse-cdt/cdt-gdb-adapter",
+      "requires": {
+        "vscode-debugadapter": "^1.32.1"
+      }
+    },
     "chalk": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
   },
   "homepage": "https://github.com/eclipse-cdt/cdt-gdb-vscode#readme",
   "dependencies": {
+    "cdt-gdb-adapter": "github:eclipse-cdt/cdt-gdb-adapter",
     "vscode-debugadapter": "^1.32.1"
   },
   "devDependencies": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,32 +1,45 @@
 const path = require('path');
+const fs = require('fs');
 
-module.exports = {
-    target: 'node',
-    mode: 'none',
-    context: __dirname,
-    resolve: {
-        extensions: [ '.ts', '.js' ]
-    },
-    entry: {
-        gdbDebugAdapter: './adapter/src/debugAdapter.ts',
-        extension: './src/extension.ts'
-    },
-    output: {
-        path: path.resolve(__dirname, 'out'),
-        filename: '[name].js',
-        libraryTarget: 'commonjs',
-        devtoolModuleFilenameTemplate: '[absolute-resource-path]'
-    },
-    devtool: 'source-map',
-    module: {
-        rules: [
-            {
-                test: /\.ts$/,
-                loader: 'ts-loader',
-            }
+let adapterDir = process.env['CDT_ADAPTER_DIR'] || '../cdt-gdb-adapter';
+if (!fs.existsSync(adapterDir)) {
+    adapterDir = 'node_modules/cdt-gdb-adapter';
+}
+adapterConfig = require(path.join(adapterDir, 'webpack.config.js'));
+
+adapterConfig.forEach((config) => {
+    config.output.path = path.resolve(__dirname, 'out');
+});
+
+module.exports = [
+    ...adapterConfig,
+    {
+        target: 'node',
+        mode: 'none',
+        context: __dirname,
+        resolve: {
+            extensions: [ '.ts', '.js' ]
+        },
+        entry: {
+            extension: './src/extension.ts'
+        },
+        output: {
+            path: path.resolve(__dirname, 'out'),
+            filename: '[name].js',
+            libraryTarget: 'commonjs',
+            devtoolModuleFilenameTemplate: '[absolute-resource-path]'
+        },
+        devtool: 'source-map',
+        module: {
+            rules: [
+                {
+                    test: /\.ts$/,
+                    loader: 'ts-loader',
+                }
+            ]
+        },
+        externals: [
+            'vscode'
         ]
-    },
-    externals: [
-        'vscode'
-    ]
-};
+    }
+];

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 
 let adapterDir = process.env['CDT_ADAPTER_DIR'] || '../cdt-gdb-adapter';
 if (!fs.existsSync(adapterDir)) {
-    adapterDir = 'node_modules/cdt-gdb-adapter';
+    adapterDir = path.join(__dirname, 'node_modules', 'cdt-gdb-adapter');
 }
 adapterConfig = require(path.join(adapterDir, 'webpack.config.js'));
 


### PR DESCRIPTION
We now expect the adapter to be checked otu somewhere and we load
in the webpack config from there and merge it with ours.
See the README file for details.