### PR TITLE
Add property  for logFile location for launch and attach.

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,10 @@
                 "type": "boolean",
                 "description": "Produce verbose log output",
                 "default": "false"
+              },
+              "logFile": {
+                "type": "string",
+                "description": "Absolute path to the file to log interaction with gdb"
               }
             }
           },
@@ -77,6 +81,10 @@
                 "type": "boolean",
                 "description": "Produce verbose log output",
                 "default": "false"
+              },
+              "logFile": {
+                "type": "string",
+                "description": "Absolute path to the file to log interaction with gdb"
               }
             }
           }


### PR DESCRIPTION
This will be passed to the adapter to set the location of the log file.