### PR TITLE
 Add cdt-gdb-adapter to bundledDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,5 +137,8 @@
     "vscode": "^1.1.21",
     "webpack": "^4.25.1",
     "webpack-cli": "^3.1.2"
-  }
+  },
+  "bundledDependencies": [
+    "cdt-gdb-adapter"
+  ]
 }


### PR DESCRIPTION
For some reason, when running "yarn pack", the out directory is
excluded.  For Theia, we would like to create archives that we can
download and use, and it works better if the "out" directory containing
the compiled scripts is included.  I suppose it won't change anything
for when it is used as a VSCode extension.

Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>