### PR TITLE
Change "postinstall" command

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "build": "tsc",
     "watch": "tsc -w",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "postinstall": "node ./node_modules/vscode/bin/install",
+    "postinstall": "node -e \"require('vscode/bin/install')\"",
     "vscode:prepublish": "yarn build",
     "vsce:package": "vsce package --yarn"
   },


### PR DESCRIPTION
Hardcoding a path to an executable living in `node_modules` can cause
issues depending on how the hoisting is done by the package manager
used.

In my case, I am using a `cdt-gdb-vscode` fork inside a mono-repo setup,
and the `vscode` package is hoisted at the mono-repo root `node_modules`,
not inside `cdt-gdb-vscode/node_modules`.

A better way to call the script is to let the node package resolution
system take care of it.

This is why this commit makes the "postinstall" command a javascript
script.

Signed-off-by: Paul Maréchal <paul.marechal@ericsson.com>