### PR TITLE
Add configuration options to open a GDB console

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,10 @@
               "logFile": {
                 "type": "string",
                 "description": "Absolute path to the file to log interaction with gdb"
+              },
+              "openGdbConsole": {
+                "type": "boolean",
+                "description": "(UNIX-only) Open a GDB console in your IDE while debugging"
               }
             }
           },
@@ -85,6 +89,10 @@
               "logFile": {
                 "type": "string",
                 "description": "Absolute path to the file to log interaction with gdb"
+              },
+              "openGdbConsole": {
+                "type": "boolean",
+                "description": "(UNIX-only) Open a GDB console in your IDE while debugging"
               }
             }
           }


### PR DESCRIPTION
Feature will only work on UNIX systems, and fallback to the default way
of starting the Debug Adapter if not supported.

Signed-off-by: Paul Maréchal <paul.marechal@ericsson.com>

---

Add new launch/attach configuration option.