### PR TITLE
Bump version to prompt Open VSX publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cdt-gdb-vscode",
-  "version": "0.0.91",
+  "version": "0.0.92",
   "description": "VS Code extension for CDT GDB debug adapter",
   "publisher": "eclipse-cdt",
   "repository": {


### PR DESCRIPTION
This PR bumps the version of the plugin listed in the `package.json`. Doing so will allow recent code changes to be picked up and published by the script that publishes the plugin to the Open VSX registry.

@jonahgraham @paul-marechal

At the moment, this plugin is only made publicly available in a packaged form via the Open VSX registry. It is currently published as an 'unowned'. Longer term it may be desirable to establish ownership of the `eclipse-cdt` namespace and publish the plugin more proactively.

Signed-off-by: Colin Grant <colin.grant@ericsson.com>