### PR TITLE
Only 1 memory browser can be shown at a time

### DIFF
--- a/src/memory/server/MemoryServer.ts
+++ b/src/memory/server/MemoryServer.ts
@@ -17,9 +17,13 @@ export class MemoryServer {
 
     constructor(context: vscode.ExtensionContext) {
         context.subscriptions.push(
-            vscode.commands.registerCommand('cdt.gdb.memory.open', () =>
-                this.openPanel(context)
-            )
+            vscode.commands.registerCommand('cdt.gdb.memory.open', () => {
+                if (this.panel) {
+                    this.panel.reveal();
+                } else {
+                    this.openPanel(context);
+                }
+            })
         );
     }
 
@@ -55,6 +59,15 @@ export class MemoryServer {
                 </body>
             </html>
         `;
+
+        // Reset when panel is disposed
+        this.panel.onDidDispose(
+            () => {
+                this.panel = undefined;
+            },
+            null,
+            context.subscriptions
+        );
     }
 
     private loadScript(context: vscode.ExtensionContext, path: string) {


### PR DESCRIPTION
@jonahgraham could you please help to review this?
We need to show only one Memory Browser tab at a moment.
This is a work-around method before we can make multiple Memory Browser tabs to show memory data.