### PR TITLE
Remove avoidable VS Code references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to the CDT GDB Debug Adapter Extension for Visual Studio Code
+# Contributing to the CDT GDB Debug Adapter Extension
 
 Thanks for your interest in this project, part of [Eclipse CDT Cloud](https://eclipse.dev/cdt-cloud/).
 
@@ -6,7 +6,7 @@ The source code can be found in the following repository: https://github.com/ecl
 
 ## Project description
 
-This is a Visual Studio Code extension that supports
+This is an extension that supports
 debugging using gdb and any other debugger that supports
 the MI protocol. It is built by the experts that provide
 the gdb support in the Eclipse C/C++ IDE (CDT).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,10 +6,8 @@ The source code can be found in the following repository: https://github.com/ecl
 
 ## Project description
 
-This is an extension that supports
-debugging using gdb and any other debugger that supports
-the MI protocol. It is built by the experts that provide
-the gdb support in the Eclipse C/C++ IDE (CDT).
+This extension supports debugging using GDB and the MI protocol. It is built
+by the experts that provide the GDB support in the Eclipse C/C++ IDE (CDT).
 
 ## Build Instructions
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,4 +1,4 @@
-# Developing the CDT GDB Debug Adapter Extension for Visual Studio Code
+# Developing the CDT GDB Debug Adapter Extension
 
 This document provides instructions and hints for how to build and develop this extension. More information on contributions to this project can be found in the [contribution guidelines](/CONTRIBUTING.md).
 
@@ -42,7 +42,7 @@ Then from this project run
 yarn link cdt-gdb-adapter
 ```
 
-You can set up a VS Code workspace that has both folders. Also make sure you have builds running in each folder to pick up updates (e.g. `yarn watch`).
+You can set up a workspace that has both folders. Also make sure you have builds running in each folder to pick up updates (e.g. `yarn watch`).
 
 The way to debug cdt-gdb-adapter works with the same principle as the example Mock Debug Adapter provided by VS Code.
 For detailed instructions please refer to [Development Setup for Mock Debug](https://code.visualstudio.com/api/extension-guides/debugger-extension#development-setup-for-mock-debug).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CDT GDB Debug Adapter Extension
 
-This is an extension that supports debugging using GDB and the MI protocol. It is built by the experts that provide the GDB support in the Eclipse C/C++ IDE (CDT).
+This is an extension for Visual Studio Code and compatible IDEs that supports debugging using GDB and the MI protocol. It is built by the experts that provide the GDB support in the Eclipse C/C++ IDE (CDT).
 
 This extension provides a number of features that integrate into your debug environment. This includes launch types, support for the standard debug views as well as a custom viewer for memory browsing.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# CDT GDB Debug Adapter Extension for Visual Studio Code
+# CDT GDB Debug Adapter Extension
 
-This is a Visual Studio Code extension that supports debugging using GDB and the MI protocol. It is built by the experts that provide the GDB support in the Eclipse C/C++ IDE (CDT).
+This is an extension that supports debugging using GDB and the MI protocol. It is built by the experts that provide the GDB support in the Eclipse C/C++ IDE (CDT).
 
-This extension provides a number of features that integrate into the Visual Studio Code debug environment. This includes launch types, support for the standard debug views as well as a custom viewer for memory browsing.
+This extension provides a number of features that integrate into your debug environment. This includes launch types, support for the standard debug views as well as a custom viewer for memory browsing.
 
 ## Prerequisites
 
@@ -13,7 +13,7 @@ External tools are expected to be present on your system depending on the intend
 
 ## Launch Configurations
 
-The Visual Studio Debug Extension for GDB contributes two debugger types:
+This extension contributes two debugger types:
 
 - `gdb`: Support for **Local GDB Debug**. Launch or attach to an already running application locally on your host machine using GDB.
 - `gdbtarget`: Support for **Remote GDB Debug**. Launch or attach to an already running remote GDB server using GDB.
@@ -129,7 +129,7 @@ Settings related to displaying UART output in the debug console. This object can
 
 ## Memory Browser
 
-The extension comes with a Memory Browser window. However, we have plans to deprecate and remove the window in favour of the Eclipse CDT Cloud [Memory Inspector](https://github.com/eclipse-cdt-cloud/vscode-memory-inspector) extension for Visual Studio Code which is available from the [Visual Studio Code Marketplace](https://marketplace.visualstudio.com/items?itemName=eclipse-cdt.memory-inspector) and the [Open VSX Registry](https://open-vsx.org/extension/eclipse-cdt/memory-inspector).
+The extension comes with a Memory Browser window. However, we have plans to deprecate and remove the window in favour of the Eclipse CDT Cloud [Memory Inspector](https://github.com/eclipse-cdt-cloud/vscode-memory-inspector) extension which is available from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=eclipse-cdt.memory-inspector) and the [Open VSX Registry](https://open-vsx.org/extension/eclipse-cdt/memory-inspector).
 
 Any feedback on these plans is welcomed in the discussion in GitHub issue [#110](https://github.com/eclipse-cdt-cloud/cdt-gdb-vscode/issues/110).
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "cdt-gdb-vscode",
   "version": "2.9.0",
   "displayName": "CDT GDB Debug Adapter Extension",
-  "description": "Extension from Eclipse CDT Cloud that integrates local and remote debugging with GDB",
+  "description": "Extension from Eclipse CDT that integrates local and remote debugging with GDB",
   "publisher": "eclipse-cdt",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "cdt-gdb-vscode",
   "version": "2.9.0",
   "displayName": "CDT GDB Debug Adapter Extension",
-  "description": "CDT GDB debug adapter extension for Visual Studio Code",
+  "description": "Extension from Eclipse CDT Cloud that integrates local and remote debugging with GDB",
   "publisher": "eclipse-cdt",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "cdt-gdb-vscode",
   "version": "2.9.0",
   "displayName": "CDT GDB Debug Adapter Extension",
-  "description": "Extension from Eclipse CDT that integrates local and remote debugging with GDB",
+  "description": "Extension from Eclipse CDT that integrates local and remote debugging with GDB in VS Code and compatible IDEs",
   "publisher": "eclipse-cdt",
   "repository": {
     "type": "git",

--- a/src/BreakpointModesController.ts
+++ b/src/BreakpointModesController.ts
@@ -47,11 +47,11 @@ export class BreakpointModesController {
                 const sp = new SourceBreakpoint(
                     new Location(values.uri, new Position(line, 0))
                 );
-                // Limitation of VSCode: https://github.com/microsoft/vscode/issues/304764
-                // This is a workaround to inject 'mode' into VS breakpoint object.
+                // Limitation of VS Code: https://github.com/microsoft/vscode/issues/304764
+                // This is a workaround to inject 'mode' into VS Code breakpoint object.
                 // This injection functionally working as expected and passes the information
                 // correctly through DAP messages, however the breakpoint mode information is not
-                // visible in the breakpoint list window in VSCode
+                // visible in the breakpoint list window
                 (sp as any).mode = mode;
                 debug.addBreakpoints([sp]);
             } catch (e) {


### PR DESCRIPTION
Removed avoidable VS Code references.
See discussion on original PR #138 .
