### PR TITLE
Add 'auxiliaryGdb' setting to 'gdbtarget' 'attach' type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Unreleased
+
+- Fixes [`184`](https://github.com/eclipse-cdt-cloud/cdt-gdb-vscode/issues/184): Add `auxiliaryGdb` setting to `attach` type for `gdbtarget`.
+
 ## 2.4.0
 
 - Implements [cdt-gdb-adapter `#442`](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/issues/442): Support auxiliary GDB connections to allow selected operations while CPU running.

--- a/package.json
+++ b/package.json
@@ -557,6 +557,11 @@
                 "description": "Use non-stop mode for controlling multiple threads. (defaults to false)",
                 "default": false
               },
+              "auxiliaryGdb": {
+                "type": "boolean",
+                "description": "Creates an auxiliary GDB connection to the target TCP port if supported by connected GDB server.\nRequires `gdbAsync` mode and cannot be used with `gdbNonStop` mode.",
+                "default": false
+              },
               "verbose": {
                 "type": "boolean",
                 "description": "Produce verbose log output",


### PR DESCRIPTION
Fixes #184 

- Adds `auxiliaryGdb` setting to `attach` type of `gdbtarget`.