### PR TITLE
Enable breakpoints in assembler files (.asm, .s, .S)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 ## Unreleased
 
-- Fixes [``](): Cannot set breakpoints in assembler files.
+- Fixes [`#191`](https://github.com/eclipse-cdt-cloud/cdt-gdb-vscode/pull/191): Cannot set breakpoints in assembler files.
 
 ## 2.4.1
 
-- Fixes [`184`](https://github.com/eclipse-cdt-cloud/cdt-gdb-vscode/issues/184): Add `auxiliaryGdb` setting to `attach` type for `gdbtarget`.
+- Fixes [`#184`](https://github.com/eclipse-cdt-cloud/cdt-gdb-vscode/issues/184): Add `auxiliaryGdb` setting to `attach` type for `gdbtarget`.
 - Update to cdt-gdb-adapter v1.4.1
-    - Fixes [cdt-gdb-adapter `400`](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/issues/400): Evaluation of variables to support RTOS Views extension.
+    - Fixes [cdt-gdb-adapter `#400`](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/issues/400): Evaluation of variables to support RTOS Views extension.
 
 ## 2.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Unreleased
+
+- Fixes [``](): Cannot set breakpoints in assembler files.
+
 ## 2.4.1
 
 - Fixes [`184`](https://github.com/eclipse-cdt-cloud/cdt-gdb-vscode/issues/184): Add `auxiliaryGdb` setting to `attach` type for `gdbtarget`.

--- a/package.json
+++ b/package.json
@@ -33,6 +33,16 @@
     "onCommand:cdt.debug.suspendAllSession"
   ],
   "contributes": {
+    "languages": [
+      {
+        "id": "cdt-gdb-asm",
+        "extensions": [
+          "asm",
+          "s",
+          "S"
+        ]
+      }
+    ],
     "commands": [
       {
         "category": "GDB",
@@ -65,6 +75,9 @@
       }
     ],
     "breakpoints": [
+      {
+        "language": "cdt-gdb-asm"
+      },
       {
         "language": "c"
       },


### PR DESCRIPTION
Defines a pseudo-language 'cdt-gdb-asm' which defines expected file endings for assembler files, and adds it to breakpoint support.