### PR TITLE
v2.7.0 Release Preparations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 22.x
       - name: Build
         run: |
           yarn install
@@ -61,7 +61,7 @@ jobs:
           path: artifacts
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 22.x
       - name: Publish
         run: |
           npx ovsx publish -i artifacts/*/*.vsix -p ${{secrets.OPEN_VSX_TOKEN}}
@@ -78,7 +78,7 @@ jobs:
           path: artifacts
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 22.x
       - name: Publish
         run: |
           npx vsce publish -i artifacts/*/*.vsix -p ${{secrets.VS_MARKETPLACE_TOKEN}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Implements [cdt-gdb-adapter `#482`](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/pull/482): Add `updateThreadInfo` setting.
 - Fixes [cdt-gdb-adapter `#432`](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/issues/432): Incorrect documentation of `initCommands`.
 - Update to cdt-gdb-adapter [v1.7.0](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/releases/tag/v1.7.0)
-    - Implements [cdt-gdb-adapter `#432`](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/issues/432)/[cdt-gdb-adapter `#476`](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/issues/432): Add `preConnectCommands` which executes GDB commands before attaching to inferior (`gdb` type) / before attaching to target (`gdbtarget` type).
+    - Implements [cdt-gdb-adapter `#432`](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/issues/432)/[cdt-gdb-adapter `#476`](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/issues/476): Add `preConnectCommands` which executes GDB commands before attaching to inferior (`gdb` type) / before attaching to target (`gdbtarget` type).
     - Implements [cdt-gdb-adapter `#482`](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/pull/482): Add `updateThreadInfo` option to control when thread info is retrieved.
     - Fixes [cdt-gdb-adapter `#483`](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/pull/483): `detach` request still occasionally getting stuck on exited program.
     - Fixes [cdt-gdb-adapter `#485`](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/issues/485): Read Memory request error message is not comprehensive enough.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,16 @@
 # Change Log
 
-## Unreleased
+## 2.7.0
 
+- Implements [cdt-gdb-adapter `#432`](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/issues/432): Add `preConnectCommands` setting.
+- Implements [cdt-gdb-adapter `#482`](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/pull/482): Add `updateThreadInfo` setting.
 - Fixes [cdt-gdb-adapter `#432`](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/issues/432): Incorrect documentation of `initCommands`.
-- Update to cdt-gdb-adapter [v?.?.?](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/releases/tag/v?.?.?)
-    - Implements [`#432`](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/issues/432): Add `preConnectCommands` setting.
-    - Implements [`#482`](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/pull/482): Add `updateThreadInfo` setting.
-
+- Update to cdt-gdb-adapter [v1.7.0](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/releases/tag/v1.7.0)
+    - Implements [cdt-gdb-adapter `#432`](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/issues/432)/[cdt-gdb-adapter `#476`](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/issues/432): Add `preConnectCommands` which executes GDB commands before attaching to inferior (`gdb` type) / before attaching to target (`gdbtarget` type).
+    - Implements [cdt-gdb-adapter `#482`](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/pull/482): Add `updateThreadInfo` option to control when thread info is retrieved.
+    - Fixes [cdt-gdb-adapter `#483`](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/pull/483): `detach` request still occasionally getting stuck on exited program.
+    - Fixes [cdt-gdb-adapter `#485`](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/issues/485): Read Memory request error message is not comprehensive enough.
+    - Fixes [cdt-gdb-adapter `#487`](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/pull/487): Uncaught exception caused by async Promise executor in `startGDBServer`.
 
 ## 2.6.0
 

--- a/package.json
+++ b/package.json
@@ -886,7 +886,7 @@
   },
   "dependencies": {
     "cdt-amalgamator": "^0.0.11",
-    "cdt-gdb-adapter": "^1.6.0",
+    "cdt-gdb-adapter": "^1.7.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cdt-gdb-vscode",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "displayName": "CDT GDB Debug Adapter Extension",
   "description": "CDT GDB debug adapter extension for Visual Studio Code",
   "publisher": "eclipse-cdt",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1223,10 +1223,10 @@ cdt-amalgamator@^0.0.11:
     "@vscode/debugadapter-testsupport" "^1.59.0"
     "@vscode/debugprotocol" "^1.59.0"
 
-cdt-gdb-adapter@^1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/cdt-gdb-adapter/-/cdt-gdb-adapter-1.6.0.tgz#4955ff995669ab784aca374d02e346d2c3211b3d"
-  integrity sha512-5Nr9tuxY1ymMPR7aAm226HN0iArrjH1wSvOtQgZOZMKRc4G+aN9slu05Yl1VQRv/dPKjUSulGwygCWYHu2QvFA==
+cdt-gdb-adapter@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/cdt-gdb-adapter/-/cdt-gdb-adapter-1.7.0.tgz#280de67f5493a1fdc841e4ab3040346e199df6b4"
+  integrity sha512-VxOd/4pUrHiK+WcYQZ6kiGclVCMhf69haVQNbx3XT91ymYYAyj4fECmHiMM27zRJGfXk6PP2Chx96kMzB2HF6g==
   dependencies:
     "@vscode/debugadapter" "^1.68.0"
     "@vscode/debugprotocol" "^1.68.0"


### PR DESCRIPTION
- Version bump to v2.7.0
- CHANGELOG updates for release
- Updated to node 22 to be consistent with coming changes in cdt-gdb-adapter.
