### PR TITLE
Feat: Setting Hardware/Software Breakpoint Types via Editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -896,11 +896,11 @@
         },
         {
           "command": "cdt.debug.breakpoints.addHardwareBreakpoint",
-          "when": "inDebugMode"
+          "when": "false"
         },
         {
           "command": "cdt.debug.breakpoints.addSoftwareBreakpoint",
-          "when": "inDebugMode"
+          "when": "false"
         }
       ],
       "editor/lineNumber/context": [

--- a/package.json
+++ b/package.json
@@ -82,6 +82,14 @@
         "command": "cdt.debug.setOutputRadixToDecimal",
         "category": "CDT-GDB",
         "title": "Set Global Output Radix to Decimal"
+      },
+      {
+        "title": "CDT-GDB: Set Hardware Breakpoint",
+        "command": "cdt.debug.breakpoints.addHardwareBreakpoint"
+      },
+      {
+        "title": "CDT-GDB: Set Software Breakpoint",
+        "command": "cdt.debug.breakpoints.addSoftwareBreakpoint"
       }
     ],
     "breakpoints": [
@@ -885,6 +893,24 @@
         {
           "command": "cdt.debug.setOutputRadixToDecimal",
           "when": "inDebugMode"
+        },
+        {
+          "command": "cdt.debug.breakpoints.addHardwareBreakpoint",
+          "when": "inDebugMode"
+        },
+        {
+          "command": "cdt.debug.breakpoints.addSoftwareBreakpoint",
+          "when": "inDebugMode"
+        }
+      ],
+      "editor/lineNumber/context": [
+        {
+          "command": "cdt.debug.breakpoints.addHardwareBreakpoint",
+          "group": "navigation"
+        },
+        {
+          "command": "cdt.debug.breakpoints.addSoftwareBreakpoint",
+          "group": "navigation"
         }
       ]
     }

--- a/src/BreakpointModesController.ts
+++ b/src/BreakpointModesController.ts
@@ -7,8 +7,6 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *********************************************************************/
-import { platform } from 'node:os';
-import { normalize } from 'node:path';
 import {
     ExtensionContext,
     Position,
@@ -19,36 +17,7 @@ import {
     window,
     Uri,
 } from 'vscode';
-
-/**
- * This function compares the given paths, returns true if they are equal.
- *
- * - The compare function normalises the paths before checking, which means '.' and '..' expressions
- *   reduced properly.
- * - For Windows, the compare function is case insensitive
- * - For Windows, the compare function also handles backslashes, forward slashes insensitively.
- * - Compare function handles undefined values, which means given paths can be undefined. No need to check
- *   undefined before sending the arguments.
- *
- * @param path1
- *      First path to compare
- * @param path2
- *      Second path to compare
- */
-export const arePathsEqual = (
-    path1: string | undefined,
-    path2: string | undefined,
-): boolean => {
-    if (!path1 || !path2) {
-        return path1 === path2;
-    }
-    const nPath1 = normalize(path1);
-    const nPath2 = normalize(path2);
-    return platform() === 'win32'
-        ? nPath1.localeCompare(nPath2, undefined, { sensitivity: 'accent' }) ===
-              0
-        : nPath1 === nPath2;
-};
+import { arePathsEqual } from './utils';
 
 export class BreakpointModesController {
     constructor(private context: ExtensionContext) {}
@@ -78,7 +47,7 @@ export class BreakpointModesController {
                 const sp = new SourceBreakpoint(
                     new Location(values.uri, new Position(line, 0)),
                 );
-                // Limitation of VSCode:
+                // Limitation of VSCode: https://github.com/microsoft/vscode/issues/304764
                 // This is a workaround to inject 'mode' into VS breakpoint object.
                 // This injection functionally working as expected and passes the information
                 // correctly through DAP messages, however the breakpoint mode information is not

--- a/src/BreakpointModesController.ts
+++ b/src/BreakpointModesController.ts
@@ -1,0 +1,109 @@
+/*********************************************************************
+ * Copyright (c) 2026 Renesas Electronics Corporation and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *********************************************************************/
+import { platform } from 'node:os';
+import { normalize } from 'node:path';
+import {
+    ExtensionContext,
+    Position,
+    Location,
+    SourceBreakpoint,
+    commands,
+    debug,
+    window,
+    Uri,
+} from 'vscode';
+
+/**
+ * This function compares the given paths, returns true if they are equal.
+ *
+ * - The compare function normalises the paths before checking, which means '.' and '..' expressions
+ *   reduced properly.
+ * - For Windows, the compare function is case insensitive
+ * - For Windows, the compare function also handles backslashes, forward slashes insensitively.
+ * - Compare function handles undefined values, which means given paths can be undefined. No need to check
+ *   undefined before sending the arguments.
+ *
+ * @param path1
+ *      First path to compare
+ * @param path2
+ *      Second path to compare
+ */
+export const arePathsEqual = (
+    path1: string | undefined,
+    path2: string | undefined,
+): boolean => {
+    if (!path1 || !path2) {
+        return path1 === path2;
+    }
+    const nPath1 = normalize(path1);
+    const nPath2 = normalize(path2);
+    return platform() === 'win32'
+        ? nPath1.localeCompare(nPath2, undefined, { sensitivity: 'accent' }) ===
+              0
+        : nPath1 === nPath2;
+};
+
+export class BreakpointModesController {
+    constructor(private context: ExtensionContext) {}
+
+    setBreakpointHandler =
+        (mode: 'hardware' | 'software') =>
+        async (values: { uri: Uri; lineNumber: number }) => {
+            try {
+                const line = values.lineNumber - 1;
+                const existingBreakpoints = debug.breakpoints.filter(
+                    (bp: Partial<SourceBreakpoint>) =>
+                        arePathsEqual(
+                            bp?.location?.uri?.path,
+                            values.uri.path,
+                        ) && bp?.location?.range?.start?.line === line,
+                );
+                if (existingBreakpoints.length) {
+                    const existingBreakpointHasDesiredMode =
+                        existingBreakpoints.findIndex(
+                            (bp: any) => bp.mode === mode,
+                        ) > -1;
+                    if (existingBreakpointHasDesiredMode) {
+                        return;
+                    }
+                    debug.removeBreakpoints(existingBreakpoints);
+                }
+                const sp = new SourceBreakpoint(
+                    new Location(values.uri, new Position(line, 0)),
+                );
+                // Limitation of VSCode:
+                // This is a workaround to inject 'mode' into VS breakpoint object.
+                // This injection functionally working as expected and passes the information
+                // correctly through DAP messages, however the breakpoint mode information is not
+                // visible in the breakpoint list window in VSCode
+                (sp as any).mode = mode;
+                debug.addBreakpoints([sp]);
+            } catch (e) {
+                window.showErrorMessage(
+                    `Failed to set ${mode} breakpoint: ${e}`,
+                );
+            }
+        };
+
+    registerCommands = () => {
+        this.context.subscriptions.push(
+            commands.registerCommand(
+                'cdt.debug.breakpoints.addHardwareBreakpoint',
+                this.setBreakpointHandler('hardware'),
+            ),
+        );
+        this.context.subscriptions.push(
+            commands.registerCommand(
+                'cdt.debug.breakpoints.addSoftwareBreakpoint',
+                this.setBreakpointHandler('software'),
+            ),
+        );
+    };
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,6 +18,7 @@ import { CustomReset } from './CustomReset';
 export { CustomReset } from './CustomReset';
 import { SwitchRadix } from './switchRadix';
 export { SwitchRadix } from './switchRadix';
+import { BreakpointModesController } from './BreakpointModesController';
 
 export function activate(context: ExtensionContext) {
     new MemoryServer(context);
@@ -40,6 +41,8 @@ export function activate(context: ExtensionContext) {
             });
         }),
     );
+    const breakpointModesController = new BreakpointModesController(context);
+    breakpointModesController.registerCommands();
 }
 
 export function deactivate() {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,41 @@
+/*********************************************************************
+ * Copyright (c) 2026 Renesas Electronics Corporation and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *********************************************************************/
+import { platform } from 'node:os';
+import { normalize } from 'node:path';
+
+/**
+ * This function compares the given paths, returns true if they are equal.
+ *
+ * - The compare function normalises the paths before checking, which means '.' and '..' expressions
+ *   reduced properly.
+ * - For Windows, the compare function is case insensitive
+ * - For Windows, the compare function also handles backslashes, forward slashes insensitively.
+ * - Compare function handles undefined values, which means given paths can be undefined. No need to check
+ *   undefined before sending the arguments.
+ *
+ * @param path1
+ *      First path to compare
+ * @param path2
+ *      Second path to compare
+ */
+export const arePathsEqual = (
+    path1: string | undefined,
+    path2: string | undefined,
+): boolean => {
+    if (!path1 || !path2) {
+        return path1 === path2;
+    }
+    const nPath1 = normalize(path1);
+    const nPath2 = normalize(path2);
+    return platform() === 'win32'
+        ? nPath1.localeCompare(nPath2, undefined, { sensitivity: 'accent' }) ===
+              0
+        : nPath1 === nPath2;
+};


### PR DESCRIPTION
## Summary

This PR exposes hardware and software breakpoint type selection to end users directly from the editor  context menu, making a capability that has long existed at the adapter level easy to discover and use.

The underlying DAP support for breakpoint modes was already implemented in `cdt-gdb-adapter`. This change wires that adapter capability into the VS Code extension UI so users no longer need to manually configure breakpoint types through launch configuration or GDB console commands.

This feature was discussed and tracked as an initiative in CDT Cloud community meetings (starting February 2024), with evaluation of the GDB DAP adapter proof-of-concept carried out earlier. This PR represents the VS Code extension layer of that initiative.

## Changes

- **`src/BreakpointModesController.ts`** — New controller that registers two commands:
  - `cdt.debug.breakpoints.addHardwareBreakpoint`
  - `cdt.debug.breakpoints.addSoftwareBreakpoint`

  Each command removes any existing breakpoint on the target line and re-adds it with the desired mode injected via a workaround on the `SourceBreakpoint` object (necessary due to a current VS Code API limitation — the mode is passed correctly through DAP but is not reflected in the breakpoints panel UI).

  The controller also exports `arePathsEqual`, a path comparison utility that handles normalisation and Windows case/slash insensitivity.

- **`src/extension.ts`** — Activates the `BreakpointModesController`.

- **`package.json`** — Contributes the two commands and surfaces them in the editor line number context menu (`editor/lineNumber/context`), with `inDebugMode` guards in the Command Palette.

## How It Works

Right-clicking on a line number in the editor while a debug session is active shows:

- **CDT-GDB: Set Hardware Breakpoint** — sets a hardware breakpoint on that line
- **CDT-GDB: Set Software Breakpoint** — sets a software breakpoint on that line

If a breakpoint already exists on the line with the requested mode, the command is a no-op. Otherwise the existing breakpoint is replaced.

<img width="803" height="211" alt="image" src="https://github.com/user-attachments/assets/8307d678-1687-4fda-b971-c1397c1ba2ef" />

## Known Limitation

VS Code does not currently expose a public API to set `mode` on a `SourceBreakpoint`. The mode is injected via `(sp as any).mode = mode`, which works functionally and is passed correctly in DAP `setBreakpoints` requests — but the breakpoint mode is not visible in the VS Code Breakpoints panel.

For more information: https://github.com/microsoft/vscode/issues/304764