### PR TITLE
Unify to Arm Limited in copyright headers

### DIFF
--- a/src/CustomReset.ts
+++ b/src/CustomReset.ts
@@ -1,5 +1,5 @@
 /*********************************************************************
- * Copyright (c) 2025 Arm Ltd. and others
+ * Copyright (c) 2025 Arm Limited and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/src/switchRadix.ts
+++ b/src/switchRadix.ts
@@ -1,5 +1,5 @@
 /*********************************************************************
- * Copyright (c) 2026 Arm and others
+ * Copyright (c) 2026 Arm Limited and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0


### PR DESCRIPTION
This PR unifies different forms of calling out Arm ("Arm", "Arm Ltd.") in copyright headers to "Arm Limited" for easier reference.