### PR TITLE
Check formatting in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,10 @@ jobs:
           yarn install
           yarn build
           yarn vsce:package
+      - name: Verify code formatting is valid
+        run: |
+          yarn format-check
+          yarn lint
       - uses: actions/upload-artifact@v4
         with:
           name: vsix-package

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,3 +1,4 @@
 {
-  "singleQuote": true
+  "singleQuote": true,
+  "trailingComma": "es5"
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ See build instructions in the [developer documentation](./DEVELOPMENT.md). Furth
 Before your contribution can be accepted by the project team contributors must
 electronically sign the Eclipse Contributor Agreement (ECA).
 
--   http://www.eclipse.org/legal/ECA.php
+- http://www.eclipse.org/legal/ECA.php
 
 Commits that are provided by non-committers must have a Signed-off-by field in
 the footer indicating that the author is aware of the terms by which the
@@ -35,4 +35,4 @@ https://www.eclipse.org/projects/handbook/#resources-commit
 
 Contact the project developers via the project's "dev" list.
 
--   https://dev.eclipse.org/mailman/listinfo/cdt-dev
+- https://dev.eclipse.org/mailman/listinfo/cdt-dev

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -19,6 +19,13 @@ You can also run the build in watch mode using
 yarn watch
 ```
 
+To format changed code consistently, run
+
+```
+yarn format
+yarn lint
+```
+
 ### Co-developing cdt-gdb-adapter
 
 If you are working on the cdt-gdb-adapter you can check it out to a different location and then link it in.

--- a/README.md
+++ b/README.md
@@ -7,14 +7,16 @@ This extension provides a number of features that integrate into the Visual Stud
 ## Prerequisites
 
 External tools are expected to be present on your system depending on the intended use case.
-* **Local GDB Debug**: A GDB installation is required on your system.
-* **Remote GDB Debug**: A GDB installation is required on your system. In addition to that you must have either access to a running GDB server instance (`attach` use case), or a suitable GDB server variant must be installed to `launch` and connect to your debug target.
+
+- **Local GDB Debug**: A GDB installation is required on your system.
+- **Remote GDB Debug**: A GDB installation is required on your system. In addition to that you must have either access to a running GDB server instance (`attach` use case), or a suitable GDB server variant must be installed to `launch` and connect to your debug target.
 
 ## Launch Configurations
 
 The Visual Studio Debug Extension for GDB contributes two debugger types:
-* `gdb`: Support for **Local GDB Debug**. Launch or attach to an already running application locally on your host machine using GDB.
-* `gdbtarget`: Support for **Remote GDB Debug**. Launch or attach to an already running remote GDB server using GDB.
+
+- `gdb`: Support for **Local GDB Debug**. Launch or attach to an already running application locally on your host machine using GDB.
+- `gdbtarget`: Support for **Remote GDB Debug**. Launch or attach to an already running remote GDB server using GDB.
 
 Both come as `launch` and `attach` request types, each with a sophisticated set of configuration settings.
 
@@ -22,28 +24,29 @@ Both come as `launch` and `attach` request types, each with a sophisticated set 
 
 Launch and attach configuration settings that can be used with the `gdb` debugger type for local GDB debug.
 
-|  Setting | `launch`  | `attach`  | Type | Description |
-|:---|:---:|:---:|:---:|:---|
-| `gdb` | x | x | `string` | Path to GDB. This can be an absolute path or the name of an executable on your PATH environment variable.<br>Default: `gdb` |
-| `cwd` | x | x | `string` | Current working directory for launching GDB.<br>Default: Directory of the debugged `program`. |
-| `environment` | x | x | `object` | Environment variables to use when launching GDB, defined as a key-value pairs. Use `null` value to remove variable.<br>Example:<pre>\"environment\": {<br>  \"VARNAME\": \"value\",<br>  \"PATH\": \"/new/item:${env:PATH}\",<br>  \"REMOVEME\": null<br>}</pre> |
-| `program` | x | x | `string` | Path to the program to be debugged. For `launch` requests, this program is also launched.<br>Default: `${workspaceFolder}/${command:askProgramPath}`, which allows to interactively enter the full program path.  |
-| `arguments` | x | | `string` | Arguments for the program. |
-| `processId` | | x | `string` | Process ID to attach to. |
-| `gdbAsync` | x | x | `boolean` | Use `mi-async` mode for communication with GDB. Always `true` if `gdbNonStop` is `true`.<br>Default: `true` |
-| `gdbNonStop` | x | x | `boolean` | Use `non-stop` mode for controlling multiple threads.<br> Default: `false` |
-| `verbose` | x | x | `boolean` | Produce verbose log output. |
-| `logFile` | x | x | `string` | Absolute path to the file to log interaction with GDB.|
-| `openGdbConsole` | x | x | `boolean` | *(UNIX-only)* Open a GDB console in your IDE while debugging. |
-| `preConnectCommands` | x | x | `string[]` | List of GDB commands sent before attaching to inferior. |
-| `initCommands` | x | x | `string[]` | List of GDB commands sent after attaching to inferior before running/continuing. |
-| `updateThreadInfo` | x | x | `string` | Controls when thread information is retrieved from GDB. See [`updateThreadInfo`](#updatethreadinfo-setting) setting section for details.<br>Supported values: `missing`, `when-requested`, `never`<br>Default: `missing` |
+| Setting              | `launch` | `attach` |    Type    | Description                                                                                                                                                                                                                                                   |
+| :------------------- | :------: | :------: | :--------: | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `gdb`                |    x     |    x     |  `string`  | Path to GDB. This can be an absolute path or the name of an executable on your PATH environment variable.<br>Default: `gdb`                                                                                                                                   |
+| `cwd`                |    x     |    x     |  `string`  | Current working directory for launching GDB.<br>Default: Directory of the debugged `program`.                                                                                                                                                                 |
+| `environment`        |    x     |    x     |  `object`  | Environment variables to use when launching GDB, defined as a key-value pairs. Use `null` value to remove variable.<br>Example:<pre>\"environment\": {<br> \"VARNAME\": \"value\",<br> \"PATH\": \"/new/item:${env:PATH}\",<br> \"REMOVEME\": null<br>}</pre> |
+| `program`            |    x     |    x     |  `string`  | Path to the program to be debugged. For `launch` requests, this program is also launched.<br>Default: `${workspaceFolder}/${command:askProgramPath}`, which allows to interactively enter the full program path.                                              |
+| `arguments`          |    x     |          |  `string`  | Arguments for the program.                                                                                                                                                                                                                                    |
+| `processId`          |          |    x     |  `string`  | Process ID to attach to.                                                                                                                                                                                                                                      |
+| `gdbAsync`           |    x     |    x     | `boolean`  | Use `mi-async` mode for communication with GDB. Always `true` if `gdbNonStop` is `true`.<br>Default: `true`                                                                                                                                                   |
+| `gdbNonStop`         |    x     |    x     | `boolean`  | Use `non-stop` mode for controlling multiple threads.<br> Default: `false`                                                                                                                                                                                    |
+| `verbose`            |    x     |    x     | `boolean`  | Produce verbose log output.                                                                                                                                                                                                                                   |
+| `logFile`            |    x     |    x     |  `string`  | Absolute path to the file to log interaction with GDB.                                                                                                                                                                                                        |
+| `openGdbConsole`     |    x     |    x     | `boolean`  | _(UNIX-only)_ Open a GDB console in your IDE while debugging.                                                                                                                                                                                                 |
+| `preConnectCommands` |    x     |    x     | `string[]` | List of GDB commands sent before attaching to inferior.                                                                                                                                                                                                       |
+| `initCommands`       |    x     |    x     | `string[]` | List of GDB commands sent after attaching to inferior before running/continuing.                                                                                                                                                                              |
+| `updateThreadInfo`   |    x     |    x     |  `string`  | Controls when thread information is retrieved from GDB. See [`updateThreadInfo`](#updatethreadinfo-setting) setting section for details.<br>Supported values: `missing`, `when-requested`, `never`<br>Default: `missing`                                      |
 
 #### `updateThreadInfo` Setting
 
 The `updateThreadInfo` setting controls when thread information is retrieved from GDB. This setting can be used with both `gdb` and `gdbtarget` debugger types.
 
 Supported values:
+
 <ul>
 <li><code>never</code>: Thread info is never retrieved, no thread names will be displayed. Good for slow links or targets that have no thread names or are single-threaded.</li>
 <li><code>missing</code> (default): Thread info is retrieved when target is stopped or when thread names are missing and GDB allows retrieval while running (when using async mode locally or non-stop mode). Good for targets whose thread names/details don't change.</li>
@@ -54,73 +57,73 @@ Supported values:
 
 Launch and attach configuration settings that can be used with the `gdbtarget` debugger type for remote GDB debug connections.
 
-|  Setting | `launch`  | `attach`  | Type | Description |
-|:---|:---:|:---:|:---:|:---|
-| `gdb` | x | x | `string` | Path to GDB. This can be an absolute path or the name of an executable on your PATH environment variable.<br>Default: `gdb` |
-| `cwd` | x | x | `string` | Current working directory for launching GDB.<br>Default: Directory of the debugged `program`. |
-| `environment` | x | x | `object` | Environment variables to use when launching GDB, defined as a key-value pairs. Use `null` value to remove variable.<br>Example:<pre>\"environment\": {<br>  \"VARNAME\": \"value\",<br>  \"PATH\": \"/new/item:${env:PATH}\",<br>  \"REMOVEME\": null<br>}</pre> |
-| `program` | x | x | `string` | Path to the program to be debugged. For `launch` requests, this program is also launched.<br>Default: `${workspaceFolder}/${command:askProgramPath}`, which allows to interactively enter the full program path.<br>**Note**: While `program` is marked as required, the debug adapter launches anyway for remote GDB connections. For example to inspect an embedded target system's memory and other hardware resources without debugging a program.  |
-| `gdbAsync` | x | x | `boolean` | Use `mi-async` mode for communication with GDB. Always `true` if `gdbNonStop` is `true`.<br>Default: `true` |
-| `gdbNonStop` | x | x | `boolean` | Use `non-stop` mode for controlling multiple threads.<br> Default: `false` |
-| `auxiliaryGdb` | x | x | `boolean` | Creates an auxiliary GDB connection to the target TCP port to allow memory accesses and expression evaluation while the target is running.<br>Default: `false`<br>**Notes**:<br>* Requires support for multiple connections to the same TCP port in connected GDB server.<br>* Requires `gdbAsync` mode and cannot be used with `gdbNonStop` mode. |
-| `verbose` | x | x | `boolean` | Produce verbose log output. |
-| `logFile` | x | x | `string` | Absolute path to the file to log interaction with GDB.|
-| `openGdbConsole` | x | x | `boolean` | *(UNIX-only)* Open a GDB console in your IDE while debugging. |
-| `preConnectCommands` | x | x | `string[]` | List of GDB commands sent to initialize GDB before attaching to target. |
-| `initCommands` | x | x | `string[]` | List of GDB commands sent to initialize debug target after attaching to it but before loading image and symbols. |
-| `preRunCommands` | x | x | `string[]` | List of GDB commands sent after loading image on target before resuming target. |
-| `imageAndSymbols` | x | x | `object` | Additional settings for loading images to the target and symbols into the debugger. See section "`imageAndSymbols` object" for details.
-| `target` | x | x |  `object` | Additional settings to configure the remote GDB target. See section "`target` object" for details. |
-| `customResetCommands` | x | x |  `string[]` | List of GDB commands to perform a RESET of the connected target, for example through `monitor ...` commands of the connected GDB server. |
-| `updateThreadInfo` | x | x | `string` | Controls when thread information is retrieved from GDB. See [`updateThreadInfo`](#updatethreadinfo-setting) setting section for details.<br>Supported values: `missing`, `when-requested`, `never`<br>Default: `missing` |
+| Setting               | `launch` | `attach` |    Type    | Description                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| :-------------------- | :------: | :------: | :--------: | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `gdb`                 |    x     |    x     |  `string`  | Path to GDB. This can be an absolute path or the name of an executable on your PATH environment variable.<br>Default: `gdb`                                                                                                                                                                                                                                                                                                                            |
+| `cwd`                 |    x     |    x     |  `string`  | Current working directory for launching GDB.<br>Default: Directory of the debugged `program`.                                                                                                                                                                                                                                                                                                                                                          |
+| `environment`         |    x     |    x     |  `object`  | Environment variables to use when launching GDB, defined as a key-value pairs. Use `null` value to remove variable.<br>Example:<pre>\"environment\": {<br> \"VARNAME\": \"value\",<br> \"PATH\": \"/new/item:${env:PATH}\",<br> \"REMOVEME\": null<br>}</pre>                                                                                                                                                                                          |
+| `program`             |    x     |    x     |  `string`  | Path to the program to be debugged. For `launch` requests, this program is also launched.<br>Default: `${workspaceFolder}/${command:askProgramPath}`, which allows to interactively enter the full program path.<br>**Note**: While `program` is marked as required, the debug adapter launches anyway for remote GDB connections. For example to inspect an embedded target system's memory and other hardware resources without debugging a program. |
+| `gdbAsync`            |    x     |    x     | `boolean`  | Use `mi-async` mode for communication with GDB. Always `true` if `gdbNonStop` is `true`.<br>Default: `true`                                                                                                                                                                                                                                                                                                                                            |
+| `gdbNonStop`          |    x     |    x     | `boolean`  | Use `non-stop` mode for controlling multiple threads.<br> Default: `false`                                                                                                                                                                                                                                                                                                                                                                             |
+| `auxiliaryGdb`        |    x     |    x     | `boolean`  | Creates an auxiliary GDB connection to the target TCP port to allow memory accesses and expression evaluation while the target is running.<br>Default: `false`<br>**Notes**:<br>_ Requires support for multiple connections to the same TCP port in connected GDB server.<br>_ Requires `gdbAsync` mode and cannot be used with `gdbNonStop` mode.                                                                                                     |
+| `verbose`             |    x     |    x     | `boolean`  | Produce verbose log output.                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| `logFile`             |    x     |    x     |  `string`  | Absolute path to the file to log interaction with GDB.                                                                                                                                                                                                                                                                                                                                                                                                 |
+| `openGdbConsole`      |    x     |    x     | `boolean`  | _(UNIX-only)_ Open a GDB console in your IDE while debugging.                                                                                                                                                                                                                                                                                                                                                                                          |
+| `preConnectCommands`  |    x     |    x     | `string[]` | List of GDB commands sent to initialize GDB before attaching to target.                                                                                                                                                                                                                                                                                                                                                                                |
+| `initCommands`        |    x     |    x     | `string[]` | List of GDB commands sent to initialize debug target after attaching to it but before loading image and symbols.                                                                                                                                                                                                                                                                                                                                       |
+| `preRunCommands`      |    x     |    x     | `string[]` | List of GDB commands sent after loading image on target before resuming target.                                                                                                                                                                                                                                                                                                                                                                        |
+| `imageAndSymbols`     |    x     |    x     |  `object`  | Additional settings for loading images to the target and symbols into the debugger. See section "`imageAndSymbols` object" for details.                                                                                                                                                                                                                                                                                                                |
+| `target`              |    x     |    x     |  `object`  | Additional settings to configure the remote GDB target. See section "`target` object" for details.                                                                                                                                                                                                                                                                                                                                                     |
+| `customResetCommands` |    x     |    x     | `string[]` | List of GDB commands to perform a RESET of the connected target, for example through `monitor ...` commands of the connected GDB server.                                                                                                                                                                                                                                                                                                               |
+| `updateThreadInfo`    |    x     |    x     |  `string`  | Controls when thread information is retrieved from GDB. See [`updateThreadInfo`](#updatethreadinfo-setting) setting section for details.<br>Supported values: `missing`, `when-requested`, `never`<br>Default: `missing`                                                                                                                                                                                                                               |
 
 #### `imageAndSymbols` Object
 
 Additional settings for loading images to the target and symbols into the debugger. This object can be used in `launch` and `attach` configurations for the `gdbtarget` debugger type for remote GDB connections.
 
-|  Setting | `launch`  | `attach`  | Type | Description |
-|:---|:---:|:---:|:---:|:---|
-| `symbolFileName` | x | x | `string` | If specified, a symbol file to load at the given (optional) offset. Also see `symbolOffset`. |
-| `symbolOffset` | x | x | `string` | If `symbolFileName` is specified, the offset added to symbol addresses when loaded. |
-| `imageFileName` | x | x | `string` | If specified, an image file to load at the given (optional) offset. Also see `imageOffset`. |
-| `imageOffset` | x | x | `string` | If `imageFileName` is specified, the offset used to load the image. |
+| Setting          | `launch` | `attach` |   Type   | Description                                                                                  |
+| :--------------- | :------: | :------: | :------: | :------------------------------------------------------------------------------------------- |
+| `symbolFileName` |    x     |    x     | `string` | If specified, a symbol file to load at the given (optional) offset. Also see `symbolOffset`. |
+| `symbolOffset`   |    x     |    x     | `string` | If `symbolFileName` is specified, the offset added to symbol addresses when loaded.          |
+| `imageFileName`  |    x     |    x     | `string` | If specified, an image file to load at the given (optional) offset. Also see `imageOffset`.  |
+| `imageOffset`    |    x     |    x     | `string` | If `imageFileName` is specified, the offset used to load the image.                          |
 
 #### `target` Object
 
 Additional settings to configure the remote GDB target. This object can be used in `launch` and `attach` configurations for the `gdbtarget` debugger type for remote GDB connections.
 
-|  Setting | `launch`  | `attach`  | Type | Description |
-|:---|:---:|:---:|:---:|:---|
-| `type` | x | x | `string` | The kind of target debugging to do. This is passed to `-target-select`.<br>Default: `remote` |
-| `parameters` | x | x | `string[]`| Target parameters for the type of target. Normally something like `localhost:12345`.<br>Default: `${host}:${port}`. |
-| `host` | x | x | `string` | Target host to connect to. Ignored if `parameters` is set.<br>Default: `localhost` |
-| `port` | x | x | `string` | Target port to connect to. Ignored if `parameters` is set.<br>Default: Value captured by `serverPortRegExp`, otherwise defaults to `2331` |
-| `cwd` | x | | `string` | Specifies the working directory of the server.<br>Default: Working directory of GDB |
-| `environment` | x | | `object` | Environment variables to use when launching server, defined as key-value pairs. Defaults to the environment used to launch GDB. Use `null` value to remove variable.<br>Example:<pre>\"environment\": {<br>  \"VARNAME\": \"value\",<br>  \"PATH\": \"/new/item:${env:PATH}\",<br>  \"REMOVEME\": null<br>}</pre> |
-| `server` | x | | `string` | The executable for the target server to launch (e.g. `gdbserver` or `JLinkGDBServerCLExe`). This can be an absolute path or the name of an executable on your PATH environment variable.<br>Default: `gdbserver` |
-| `serverParameters` | x | | `string[]` | Command line arguments passed to server.<br>Default: `--once :0 ${args.program}` |
-| `serverPortRegExp` | x | | `string` | Regular expression to extract `port` from by examining stdout/stderr of the GDB server. Once the server is launched, `port` will be set to this if unspecified. Defaults to matching a string like `Listening on port 41551` which is what `gdbserver` provides. Ignored if `port` or `parameters` is set. |
-| `portDetectionTimeout` | x | | `number` | Timeout for port detection based on `serverPortRegExp`. Default value is `10000` (ms). |
-| `serverDisconnectTimeout` | x | | `number` |Timeout for GDB server disconnect request. Default value is 1000 (ms). |
-| `serverStartupDelay` | x | | `number` | Delay, in milliseconds, after startup but before continuing launch. If `serverPortRegExp` is provided, it is the delay after that regexp is seen. |
-| `automaticallyKillServer` | x | | `boolean` | Automatically terminate the launched server when client issues a disconnect.<br>Default: `true` |
-| `watchServerProcess` | x | | `boolean` | Watch server process and handle when it (unexpectedly) exits.<br>Default: `true` |
-| `uart` | x | x | `object` | Settings related to displaying UART output in the debug console. |
+| Setting                   | `launch` | `attach` |    Type    | Description                                                                                                                                                                                                                                                                                                    |
+| :------------------------ | :------: | :------: | :--------: | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `type`                    |    x     |    x     |  `string`  | The kind of target debugging to do. This is passed to `-target-select`.<br>Default: `remote`                                                                                                                                                                                                                   |
+| `parameters`              |    x     |    x     | `string[]` | Target parameters for the type of target. Normally something like `localhost:12345`.<br>Default: `${host}:${port}`.                                                                                                                                                                                            |
+| `host`                    |    x     |    x     |  `string`  | Target host to connect to. Ignored if `parameters` is set.<br>Default: `localhost`                                                                                                                                                                                                                             |
+| `port`                    |    x     |    x     |  `string`  | Target port to connect to. Ignored if `parameters` is set.<br>Default: Value captured by `serverPortRegExp`, otherwise defaults to `2331`                                                                                                                                                                      |
+| `cwd`                     |    x     |          |  `string`  | Specifies the working directory of the server.<br>Default: Working directory of GDB                                                                                                                                                                                                                            |
+| `environment`             |    x     |          |  `object`  | Environment variables to use when launching server, defined as key-value pairs. Defaults to the environment used to launch GDB. Use `null` value to remove variable.<br>Example:<pre>\"environment\": {<br> \"VARNAME\": \"value\",<br> \"PATH\": \"/new/item:${env:PATH}\",<br> \"REMOVEME\": null<br>}</pre> |
+| `server`                  |    x     |          |  `string`  | The executable for the target server to launch (e.g. `gdbserver` or `JLinkGDBServerCLExe`). This can be an absolute path or the name of an executable on your PATH environment variable.<br>Default: `gdbserver`                                                                                               |
+| `serverParameters`        |    x     |          | `string[]` | Command line arguments passed to server.<br>Default: `--once :0 ${args.program}`                                                                                                                                                                                                                               |
+| `serverPortRegExp`        |    x     |          |  `string`  | Regular expression to extract `port` from by examining stdout/stderr of the GDB server. Once the server is launched, `port` will be set to this if unspecified. Defaults to matching a string like `Listening on port 41551` which is what `gdbserver` provides. Ignored if `port` or `parameters` is set.     |
+| `portDetectionTimeout`    |    x     |          |  `number`  | Timeout for port detection based on `serverPortRegExp`. Default value is `10000` (ms).                                                                                                                                                                                                                         |
+| `serverDisconnectTimeout` |    x     |          |  `number`  | Timeout for GDB server disconnect request. Default value is 1000 (ms).                                                                                                                                                                                                                                         |
+| `serverStartupDelay`      |    x     |          |  `number`  | Delay, in milliseconds, after startup but before continuing launch. If `serverPortRegExp` is provided, it is the delay after that regexp is seen.                                                                                                                                                              |
+| `automaticallyKillServer` |    x     |          | `boolean`  | Automatically terminate the launched server when client issues a disconnect.<br>Default: `true`                                                                                                                                                                                                                |
+| `watchServerProcess`      |    x     |          | `boolean`  | Watch server process and handle when it (unexpectedly) exits.<br>Default: `true`                                                                                                                                                                                                                               |
+| `uart`                    |    x     |    x     |  `object`  | Settings related to displaying UART output in the debug console.                                                                                                                                                                                                                                               |
 
 ##### `uart` object
 
 Settings related to displaying UART output in the debug console. This object can be used in the `target` object of `launch` and `attach` configurations for the `gdbtarget` debugger type for remote GDB connections.
 
-|  Setting | `launch`  | `attach`  | Type | Description |
-|:---|:---:|:---:|:---:|:---|
-| `serialPort` | x | x | `string` | Path to the serial port connected to the UART on the board. |
-| `socketPort` | x | x | `string` | Target TCP port on the host machine to attach socket to print UART output.<br>Default: `3456` |
-| `baudRate` | x | x | `number` | Baud Rate (in bits/s) of the serial port to be opened.<br>Default: `115200`.|
-| `characterSize` | x | x | `number` | The number of bits in each character of data sent across the serial line.<br>Supported values: `5`, `6`, `7`, `8`<br>Default: `8` |
-| `parity` | x | x | `string` | The type of parity check enabled with the transmitted data.<br>Supported values: `none`, `odd`, `even`, `mark`, `space`<br>Default: `none` - no parity bit sent |
-| `stopBits` | x | x | `number` | The number of stop bits sent to allow the receiver to detect the end of characters and resynchronize with the character stream.<br>Supported values: `1`, `1.5`, `2`<br>Default: `1` |
-| `handshakingMethod` | x | x | `string` | The handshaking method used for flow control across the serial line.<br>Supported values: `none`, `XON/XOFF`, `RTS/CTS`<br>Default: `none` - no handshaking |
-| `eolCharacter` | x | x | `string` | The EOL character used to parse the UART output line-by-line.<br>Supported values: `LF`, `CRLF`<br>Default: `LF` |
+| Setting             | `launch` | `attach` |   Type   | Description                                                                                                                                                                          |
+| :------------------ | :------: | :------: | :------: | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `serialPort`        |    x     |    x     | `string` | Path to the serial port connected to the UART on the board.                                                                                                                          |
+| `socketPort`        |    x     |    x     | `string` | Target TCP port on the host machine to attach socket to print UART output.<br>Default: `3456`                                                                                        |
+| `baudRate`          |    x     |    x     | `number` | Baud Rate (in bits/s) of the serial port to be opened.<br>Default: `115200`.                                                                                                         |
+| `characterSize`     |    x     |    x     | `number` | The number of bits in each character of data sent across the serial line.<br>Supported values: `5`, `6`, `7`, `8`<br>Default: `8`                                                    |
+| `parity`            |    x     |    x     | `string` | The type of parity check enabled with the transmitted data.<br>Supported values: `none`, `odd`, `even`, `mark`, `space`<br>Default: `none` - no parity bit sent                      |
+| `stopBits`          |    x     |    x     | `number` | The number of stop bits sent to allow the receiver to detect the end of characters and resynchronize with the character stream.<br>Supported values: `1`, `1.5`, `2`<br>Default: `1` |
+| `handshakingMethod` |    x     |    x     | `string` | The handshaking method used for flow control across the serial line.<br>Supported values: `none`, `XON/XOFF`, `RTS/CTS`<br>Default: `none` - no handshaking                          |
+| `eolCharacter`      |    x     |    x     | `string` | The EOL character used to parse the UART output line-by-line.<br>Supported values: `LF`, `CRLF`<br>Default: `LF`                                                                     |
 
 ## Memory Browser
 

--- a/src/BreakpointModesController.ts
+++ b/src/BreakpointModesController.ts
@@ -31,13 +31,13 @@ export class BreakpointModesController {
                     (bp: Partial<SourceBreakpoint>) =>
                         arePathsEqual(
                             bp?.location?.uri?.path,
-                            values.uri.path,
-                        ) && bp?.location?.range?.start?.line === line,
+                            values.uri.path
+                        ) && bp?.location?.range?.start?.line === line
                 );
                 if (existingBreakpoints.length) {
                     const existingBreakpointHasDesiredMode =
                         existingBreakpoints.findIndex(
-                            (bp: any) => bp.mode === mode,
+                            (bp: any) => bp.mode === mode
                         ) > -1;
                     if (existingBreakpointHasDesiredMode) {
                         return;
@@ -45,7 +45,7 @@ export class BreakpointModesController {
                     debug.removeBreakpoints(existingBreakpoints);
                 }
                 const sp = new SourceBreakpoint(
-                    new Location(values.uri, new Position(line, 0)),
+                    new Location(values.uri, new Position(line, 0))
                 );
                 // Limitation of VSCode: https://github.com/microsoft/vscode/issues/304764
                 // This is a workaround to inject 'mode' into VS breakpoint object.
@@ -56,7 +56,7 @@ export class BreakpointModesController {
                 debug.addBreakpoints([sp]);
             } catch (e) {
                 window.showErrorMessage(
-                    `Failed to set ${mode} breakpoint: ${e}`,
+                    `Failed to set ${mode} breakpoint: ${e}`
                 );
             }
         };
@@ -65,14 +65,14 @@ export class BreakpointModesController {
         this.context.subscriptions.push(
             commands.registerCommand(
                 'cdt.debug.breakpoints.addHardwareBreakpoint',
-                this.setBreakpointHandler('hardware'),
-            ),
+                this.setBreakpointHandler('hardware')
+            )
         );
         this.context.subscriptions.push(
             commands.registerCommand(
                 'cdt.debug.breakpoints.addSoftwareBreakpoint',
-                this.setBreakpointHandler('software'),
-            ),
+                this.setBreakpointHandler('software')
+            )
         );
     };
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,7 +31,7 @@ export function activate(context: ExtensionContext) {
             return window.showInputBox({
                 placeHolder: 'Please enter the path to the program',
             });
-        }),
+        })
     );
 
     context.subscriptions.push(
@@ -39,7 +39,7 @@ export function activate(context: ExtensionContext) {
             return window.showInputBox({
                 placeHolder: 'Please enter ID of process to attach to',
             });
-        }),
+        })
     );
     const breakpointModesController = new BreakpointModesController(context);
     breakpointModesController.registerCommands();

--- a/src/memory/client/MessageBroker.ts
+++ b/src/memory/client/MessageBroker.ts
@@ -50,12 +50,13 @@ class MessageBroker {
 
     sendGetChildrenNames<
         Req extends ChildDapNamesClientRequest,
-        Resp extends ChildDapNamesServerResponse
+        Resp extends ChildDapNamesServerResponse,
     >(request: Req): Promise<Resp> {
         return new Promise<Resp>((resolve, reject) => {
             request.token = this.currentToken++;
-            this.queue[request.token] = (result: ChildDapNamesServerResponse) =>
-                result.err ? reject(result.err) : resolve(result as Resp);
+            this.queue[request.token] = (
+                result: ChildDapNamesServerResponse
+            ) => (result.err ? reject(result.err) : resolve(result as Resp));
             vscode.postMessage(request);
         });
     }

--- a/src/switchRadix.ts
+++ b/src/switchRadix.ts
@@ -16,23 +16,49 @@ type Radix = 'hexadecimal' | 'decimal' | 'others';
 export class SwitchRadix {
     private _sessionsMap: Map<string, Radix> = new Map();
     constructor(context: vscode.ExtensionContext) {
-        vscode.debug.onDidChangeActiveDebugSession((session) => this.setCurrentRadixContext(session));
-        vscode.debug.onDidStartDebugSession((session) => this.addCurrentRadixContext(session));
-        vscode.debug.onDidTerminateDebugSession((session) => this._sessionsMap.delete(session.id));
-        vscode.commands.executeCommand('setContext', 'cdt.debug.outputRadix', 'decimal');
-        vscode.debug.onDidReceiveDebugSessionCustomEvent((event) => this.handleOnDidReceiveCustomEvent(event));
+        vscode.debug.onDidChangeActiveDebugSession((session) =>
+            this.setCurrentRadixContext(session)
+        );
+        vscode.debug.onDidStartDebugSession((session) =>
+            this.addCurrentRadixContext(session)
+        );
+        vscode.debug.onDidTerminateDebugSession((session) =>
+            this._sessionsMap.delete(session.id)
+        );
+        vscode.commands.executeCommand(
+            'setContext',
+            'cdt.debug.outputRadix',
+            'decimal'
+        );
+        vscode.debug.onDidReceiveDebugSessionCustomEvent((event) =>
+            this.handleOnDidReceiveCustomEvent(event)
+        );
         this.registerCommands(context);
     }
 
-    private handleOnDidReceiveCustomEvent(event: vscode.DebugSessionCustomEvent) {
-        if(event.session.type === 'gdb' || event.session.type === 'gdbtarget') {
+    private handleOnDidReceiveCustomEvent(
+        event: vscode.DebugSessionCustomEvent
+    ) {
+        if (
+            event.session.type === 'gdb' ||
+            event.session.type === 'gdbtarget'
+        ) {
             if (event.event === 'OutputRadixUpdated') {
-                if(event.body.radix === '16' || event.body.radix === '10') {
-                    const radix = event.body.radix === '16' ? 'hexadecimal' : 'decimal';
+                if (event.body.radix === '16' || event.body.radix === '10') {
+                    const radix =
+                        event.body.radix === '16' ? 'hexadecimal' : 'decimal';
                     this._sessionsMap.set(event.session.id, radix);
-                    vscode.commands.executeCommand('setContext', 'cdt.debug.outputRadix', radix);
+                    vscode.commands.executeCommand(
+                        'setContext',
+                        'cdt.debug.outputRadix',
+                        radix
+                    );
                 } else {
-                    vscode.commands.executeCommand('setContext', 'cdt.debug.outputRadix', 'others');
+                    vscode.commands.executeCommand(
+                        'setContext',
+                        'cdt.debug.outputRadix',
+                        'others'
+                    );
                     this._sessionsMap.set(event.session.id, 'others');
                 }
             }
@@ -42,7 +68,11 @@ export class SwitchRadix {
     private addCurrentRadixContext(session: vscode.DebugSession) {
         if (!this._sessionsMap.has(session.id)) {
             this._sessionsMap.set(session.id, 'decimal');
-            vscode.commands.executeCommand('setContext', 'cdt.debug.outputRadix', 'decimal');
+            vscode.commands.executeCommand(
+                'setContext',
+                'cdt.debug.outputRadix',
+                'decimal'
+            );
         }
     }
 
@@ -53,7 +83,11 @@ export class SwitchRadix {
         // Check if the session is already in the map
         const existingSessionRadix = this._sessionsMap.get(session.id);
         if (existingSessionRadix) {
-            vscode.commands.executeCommand('setContext', 'cdt.debug.outputRadix', existingSessionRadix);
+            vscode.commands.executeCommand(
+                'setContext',
+                'cdt.debug.outputRadix',
+                existingSessionRadix
+            );
             return;
         }
     }
@@ -66,8 +100,12 @@ export class SwitchRadix {
                 if (activeSession) {
                     this._sessionsMap.set(activeSession.id, 'hexadecimal');
                 }
-                await vscode.commands.executeCommand('setContext', 'cdt.debug.outputRadix', 'hexadecimal');
-            },
+                await vscode.commands.executeCommand(
+                    'setContext',
+                    'cdt.debug.outputRadix',
+                    'hexadecimal'
+                );
+            }
         );
 
         const setOutputRadixToDecimalCommand = vscode.commands.registerCommand(
@@ -78,12 +116,16 @@ export class SwitchRadix {
                 if (activeSession) {
                     this._sessionsMap.set(activeSession.id, 'decimal');
                 }
-                await vscode.commands.executeCommand('setContext', 'cdt.debug.outputRadix', 'decimal');
-            },
+                await vscode.commands.executeCommand(
+                    'setContext',
+                    'cdt.debug.outputRadix',
+                    'decimal'
+                );
+            }
         );
         context.subscriptions.push(
             setOutputRadixToHexCommand,
-            setOutputRadixToDecimalCommand,
+            setOutputRadixToDecimalCommand
         );
     }
 
@@ -94,13 +136,10 @@ export class SwitchRadix {
             context: 'repl',
         };
         try {
-            await activeSession?.customRequest(
-                'evaluate',
-                args,
-            );
+            await activeSession?.customRequest('evaluate', args);
         } catch (error) {
             vscode.window.showErrorMessage(
-                `Failed to set output radix to ${radix}: ${error}`,
+                `Failed to set output radix to ${radix}: ${error}`
             );
         }
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -27,7 +27,7 @@ import { normalize } from 'node:path';
  */
 export const arePathsEqual = (
     path1: string | undefined,
-    path2: string | undefined,
+    path2: string | undefined
 ): boolean => {
     if (!path1 || !path2) {
         return path1 === path2;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,5 +16,5 @@
     "sourceMap": true,
     "preserveWatchOutput": true
   },
-  "references": [{ "path": "src/memory/tsconfig.json" }],
+  "references": [{ "path": "src/memory/tsconfig.json" }]
 }


### PR DESCRIPTION
It looks like nobody has run `yarn format` on this project for a long time. (I only did because I noticed some inconsistent spacing in a previous PR.) If we still find automatic code formatting useful and provide this command, I propose that we also check it in pull request CI, otherwise the formatting diverges over time.

I have no strong opinion myself.

I took the liberty of adding `"trailingComma": "es5"` because
- we do the same in cdt-gdb-adapter,
- it makes a shorter diff to the existing code style,
- trailing commas in argument lists look weird to me (they are useful in array literals, but argument lists are a different thing).