### PR TITLE
Add source code highlighting

### DIFF
--- a/src/SourceFileHighlighting.ts
+++ b/src/SourceFileHighlighting.ts
@@ -18,7 +18,7 @@ export class SourceFileHighlighting {
         vscode.window.createTextEditorDecorationType({
             borderWidth: '0 0 0 2px',
             borderStyle: 'solid',
-            borderColor: 'rgba(102, 145, 255, 0.85)',
+            borderColor: new vscode.ThemeColor('editorLineNumber.foreground'),
             isWholeLine: true,
         });
 

--- a/src/SourceFileHighlighting.ts
+++ b/src/SourceFileHighlighting.ts
@@ -19,7 +19,6 @@ import { DebugProtocol } from '@vscode/debugprotocol';
 
 export class SourceFileHighlighting {
     private activeDebugSession: vscode.DebugSession | undefined;
-    private activeTextEditor: vscode.TextEditor | undefined;
     private context: vscode.ExtensionContext;
     private executableLineDecorator = vscode.window.createTextEditorDecorationType({
         borderWidth: '0 0 0 2px',
@@ -42,13 +41,10 @@ export class SourceFileHighlighting {
                 this.clearExecutableLineDecorations(vscode.window.visibleTextEditors);
             }
             this.activeDebugSession = session;
-            // Get current active text editor
-            this.activeTextEditor = vscode.window.activeTextEditor
-            this.handleOnDidChangeActiveTextEditor(this.activeTextEditor);
+            this.handleOnDidChangeActiveTextEditor(vscode.window.activeTextEditor);
         });
         const onDidChangeActiveTextEditorDisposable = vscode.window.onDidChangeActiveTextEditor(editor => {
-            this.activeTextEditor = editor;
-            this.handleOnDidChangeActiveTextEditor(editor);
+            this.handleOnDidChangeActiveTextEditor(vscode.window.activeTextEditor);
         });
 
         this.context.subscriptions.push(onDidChangeActiveDebugSessionDisposable, onDidChangeActiveTextEditorDisposable);
@@ -81,7 +77,6 @@ export class SourceFileHighlighting {
             };
         });
         editor.setDecorations(this.executableLineDecorator, decorations);
-        // reload current editor
     }
 
     private async getBreakpointLocations(editor: vscode.TextEditor): Promise<DebugProtocol.BreakpointLocationsResponse['body'] | void> {

--- a/src/SourceFileHighlighting.ts
+++ b/src/SourceFileHighlighting.ts
@@ -20,12 +20,13 @@ import { DebugProtocol } from '@vscode/debugprotocol';
 export class SourceFileHighlighting {
     private activeDebugSession: vscode.DebugSession | undefined;
     private context: vscode.ExtensionContext;
-    private executableLineDecorator = vscode.window.createTextEditorDecorationType({
-        borderWidth: '0 0 0 2px',
-        borderStyle: 'solid',
-        borderColor: 'rgba(102, 145, 255, 0.85)',
-        isWholeLine: true
-    });
+    private executableLineDecorator =
+        vscode.window.createTextEditorDecorationType({
+            borderWidth: '0 0 0 2px',
+            borderStyle: 'solid',
+            borderColor: 'rgba(102, 145, 255, 0.85)',
+            isWholeLine: true,
+        });
 
     constructor(context: vscode.ExtensionContext) {
         this.context = context;
@@ -36,27 +37,40 @@ export class SourceFileHighlighting {
     }
 
     private registerToEvents(): void {
-        const onDidChangeActiveDebugSessionDisposable = vscode.debug.onDidChangeActiveDebugSession(session => {
-            if (!session) {
-                this.clearExecutableLineDecorations(vscode.window.visibleTextEditors);
-            }
-            this.activeDebugSession = session;
-            this.handleOnDidChangeActiveTextEditor(vscode.window.activeTextEditor);
-        });
-        const onDidChangeActiveTextEditorDisposable = vscode.window.onDidChangeActiveTextEditor(editor => {
-            this.handleOnDidChangeActiveTextEditor(editor);
-        });
+        const onDidChangeActiveDebugSessionDisposable =
+            vscode.debug.onDidChangeActiveDebugSession((session) => {
+                if (!session) {
+                    this.clearExecutableLineDecorations(
+                        vscode.window.visibleTextEditors
+                    );
+                }
+                this.activeDebugSession = session;
+                this.handleOnDidChangeActiveTextEditor(
+                    vscode.window.activeTextEditor
+                );
+            });
+        const onDidChangeActiveTextEditorDisposable =
+            vscode.window.onDidChangeActiveTextEditor((editor) => {
+                this.handleOnDidChangeActiveTextEditor(editor);
+            });
 
-        this.context.subscriptions.push(onDidChangeActiveDebugSessionDisposable, onDidChangeActiveTextEditorDisposable);
+        this.context.subscriptions.push(
+            onDidChangeActiveDebugSessionDisposable,
+            onDidChangeActiveTextEditorDisposable
+        );
     }
 
-    private clearExecutableLineDecorations(editors: readonly vscode.TextEditor[]): void {
+    private clearExecutableLineDecorations(
+        editors: readonly vscode.TextEditor[]
+    ): void {
         for (const editor of editors) {
             editor.setDecorations(this.executableLineDecorator, []);
         }
     }
 
-    private async handleOnDidChangeActiveTextEditor(editor: vscode.TextEditor | undefined): Promise<void> {
+    private async handleOnDidChangeActiveTextEditor(
+        editor: vscode.TextEditor | undefined
+    ): Promise<void> {
         if (!editor) {
             return;
         }
@@ -69,8 +83,14 @@ export class SourceFileHighlighting {
             this.clearExecutableLineDecorations([editor]);
             return;
         }
-        const executableLines = new Set(breakpointLocations.breakpoints.map((bp: DebugProtocol.BreakpointLocation) => bp.line));
-        const decorations: vscode.DecorationOptions[] = Array.from(executableLines).map((exeline: number) => {
+        const executableLines = new Set(
+            breakpointLocations.breakpoints.map(
+                (bp: DebugProtocol.BreakpointLocation) => bp.line
+            )
+        );
+        const decorations: vscode.DecorationOptions[] = Array.from(
+            executableLines
+        ).map((exeline: number) => {
             const line = exeline - 1; // Convert to 0-based index
             return {
                 range: new vscode.Range(line, 0, line, 0),
@@ -79,7 +99,9 @@ export class SourceFileHighlighting {
         editor.setDecorations(this.executableLineDecorator, decorations);
     }
 
-    private async getBreakpointLocations(editor: vscode.TextEditor): Promise<DebugProtocol.BreakpointLocationsResponse['body'] | void> {
+    private async getBreakpointLocations(
+        editor: vscode.TextEditor
+    ): Promise<DebugProtocol.BreakpointLocationsResponse['body'] | void> {
         if (editor.document.uri.scheme !== 'file') {
             return;
         }
@@ -89,7 +111,11 @@ export class SourceFileHighlighting {
             line: 1,
             endLine: editor.document.lineCount, // Requesting breakpoint locations for the whole file
         };
-        const breakpointLocations = await this.activeDebugSession?.customRequest('breakpointLocations', args);
+        const breakpointLocations =
+            await this.activeDebugSession?.customRequest(
+                'breakpointLocations',
+                args
+            );
         return breakpointLocations;
     }
 }

--- a/src/SourceFileHighlighting.ts
+++ b/src/SourceFileHighlighting.ts
@@ -42,6 +42,8 @@ export class SourceFileHighlighting {
                 this.clearExecutableLineDecorations(vscode.window.visibleTextEditors);
             }
             this.activeDebugSession = session;
+            // Get current active text editor
+            this.activeTextEditor = vscode.window.activeTextEditor
             this.handleOnDidChangeActiveTextEditor(this.activeTextEditor);
         });
         const onDidChangeActiveTextEditorDisposable = vscode.window.onDidChangeActiveTextEditor(editor => {
@@ -79,6 +81,7 @@ export class SourceFileHighlighting {
             };
         });
         editor.setDecorations(this.executableLineDecorator, decorations);
+        // reload current editor
     }
 
     private async getBreakpointLocations(editor: vscode.TextEditor): Promise<DebugProtocol.BreakpointLocationsResponse['body'] | void> {

--- a/src/SourceFileHighlighting.ts
+++ b/src/SourceFileHighlighting.ts
@@ -1,18 +1,12 @@
-/**
- * Copyright 2026 Arm Limited
+/*********************************************************************
+ * Copyright (c) 2026 Arm Limited and others
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+ * SPDX-License-Identifier: EPL-2.0
+ *********************************************************************/
 
 import * as vscode from 'vscode';
 import { DebugProtocol } from '@vscode/debugprotocol';

--- a/src/SourceFileHighlighting.ts
+++ b/src/SourceFileHighlighting.ts
@@ -44,7 +44,7 @@ export class SourceFileHighlighting {
             this.handleOnDidChangeActiveTextEditor(vscode.window.activeTextEditor);
         });
         const onDidChangeActiveTextEditorDisposable = vscode.window.onDidChangeActiveTextEditor(editor => {
-            this.handleOnDidChangeActiveTextEditor(vscode.window.activeTextEditor);
+            this.handleOnDidChangeActiveTextEditor(editor);
         });
 
         this.context.subscriptions.push(onDidChangeActiveDebugSessionDisposable, onDidChangeActiveTextEditorDisposable);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,6 +19,7 @@ export { CustomReset } from './CustomReset';
 import { SwitchRadix } from './switchRadix';
 export { SwitchRadix } from './switchRadix';
 import { BreakpointModesController } from './BreakpointModesController';
+import { SourceFileHighlighting } from './sourceFileHighlighting';
 
 export function activate(context: ExtensionContext) {
     new MemoryServer(context);
@@ -26,6 +27,7 @@ export function activate(context: ExtensionContext) {
     new SuspendAllSession(context);
     new CustomReset(context);
     new SwitchRadix(context);
+    new SourceFileHighlighting(context).activate();
     context.subscriptions.push(
         commands.registerCommand('cdt.debug.askProgramPath', (_config) => {
             return window.showInputBox({

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,7 +19,7 @@ export { CustomReset } from './CustomReset';
 import { SwitchRadix } from './switchRadix';
 export { SwitchRadix } from './switchRadix';
 import { BreakpointModesController } from './BreakpointModesController';
-import { SourceFileHighlighting } from './sourceFileHighlighting';
+import { SourceFileHighlighting } from './SourceFileHighlighting';
 
 export function activate(context: ExtensionContext) {
     new MemoryServer(context);

--- a/src/sourceFileHighlighting
+++ b/src/sourceFileHighlighting
@@ -1,0 +1,97 @@
+/**
+ * Copyright 2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as vscode from 'vscode';
+import { DebugProtocol } from '@vscode/debugprotocol';
+
+export class SourceFileHighlighting {
+    private activeDebugSession: vscode.DebugSession | undefined;
+    private activeTextEditor: vscode.TextEditor | undefined;
+    private context: vscode.ExtensionContext;
+    private executableLineDecorator = vscode.window.createTextEditorDecorationType({
+        borderWidth: '0 0 0 2px',
+        borderStyle: 'solid',
+        borderColor: 'rgba(102, 145, 255, 0.85)',
+        isWholeLine: true
+    });
+
+    constructor(context: vscode.ExtensionContext) {
+        this.context = context;
+    }
+
+    public activate(): void {
+        this.registerToEvents();
+    }
+
+    private registerToEvents(): void {
+        const onDidChangeActiveDebugSessionDisposable = vscode.debug.onDidChangeActiveDebugSession(session => {
+            if (!session) {
+                this.clearExecutableLineDecorations(vscode.window.visibleTextEditors);
+            }
+            this.activeDebugSession = session;
+            this.handleOnDidChangeActiveTextEditor(this.activeTextEditor);
+        });
+        const onDidChangeActiveTextEditorDisposable = vscode.window.onDidChangeActiveTextEditor(editor => {
+            this.activeTextEditor = editor;
+            this.handleOnDidChangeActiveTextEditor(editor);
+        });
+
+        this.context.subscriptions.push(onDidChangeActiveDebugSessionDisposable, onDidChangeActiveTextEditorDisposable);
+    }
+
+    private clearExecutableLineDecorations(editors: readonly vscode.TextEditor[]): void {
+        for (const editor of editors) {
+            editor.setDecorations(this.executableLineDecorator, []);
+        }
+    }
+
+    private async handleOnDidChangeActiveTextEditor(editor: vscode.TextEditor | undefined): Promise<void> {
+        if (!editor) {
+            return;
+        }
+        if (!this.activeDebugSession) {
+            this.clearExecutableLineDecorations([editor]);
+            return;
+        }
+        const breakpointLocations = await this.getBreakpointLocations(editor);
+        if (!breakpointLocations) {
+            this.clearExecutableLineDecorations([editor]);
+            return;
+        }
+        const executableLines = new Set(breakpointLocations.breakpoints.map((bp: DebugProtocol.BreakpointLocation) => bp.line));
+        const decorations: vscode.DecorationOptions[] = Array.from(executableLines).map((exeline: number) => {
+            const line = exeline - 1; // Convert to 0-based index
+            return {
+                range: new vscode.Range(line, 0, line, 0),
+            };
+        });
+        editor.setDecorations(this.executableLineDecorator, decorations);
+    }
+
+    private async getBreakpointLocations(editor: vscode.TextEditor): Promise<DebugProtocol.BreakpointLocationsResponse['body'] | void> {
+        if (editor.document.uri.scheme !== 'file') {
+            return;
+        }
+        const currentSourceFile = editor.document.fileName;
+        const args: DebugProtocol.BreakpointLocationsArguments = {
+            source: { path: currentSourceFile },
+            line: 1,
+            endLine: editor.document.lineCount, // Requesting breakpoint locations for the whole file
+        };
+        const breakpointLocations = await this.activeDebugSession?.customRequest('breakpointLocations', args);
+        return breakpointLocations;
+    }
+}


### PR DESCRIPTION
- This PR totally depends on https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/pull/537
- Whenever user switches to a different source file, the system retrieves lines in which users can install breakpoints
- These lines are then highlighted

Note: We can agree on what colour to choose for highlighting, that wouldn't be a major change



<img width="589" height="417" alt="image" src="https://github.com/user-attachments/assets/15b0ecc5-a2ea-4926-8535-ec1cc6398c4f" />
