### PR TITLE
v2.8.0 release preparation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Change Log
 
-## Unreleased
+## 2.8.0
 
 - Implements [cdt-gdb-adapter `#201`](https://github.com/eclipse-cdt-cloud/cdt-gdb-vscode/issues/201): Add a command that allow users to change GDB session radix
+- Implements [cdt-gdb-adapter `#206`](https://github.com/eclipse-cdt-cloud/cdt-gdb-vscode/issues/206): Add "Set Output Radix" commands to context menus
+- Implements [cdt-gdb-adapter `#210`](https://github.com/eclipse-cdt-cloud/cdt-gdb-vscode/issues/210): Support value formatting for single expressions
+- Implements [cdt-gdb-adapter `#224`](https://github.com/eclipse-cdt-cloud/cdt-gdb-vscode/pull/224): Add source code highlighting
+- Fixes [cdt-gdb-adapter `#218`](https://github.com/eclipse-cdt-cloud/cdt-gdb-vscode/issues/218): Race condition when using breakpoint modes to set HW/SW breaks
+- Update to cdt-gdb-adapter [v1.9.0](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/releases/tag/v1.9.0)
+    - Implements [`#527`](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/issues/527): Support setting expression values
 
 ## 2.7.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 - Implements [cdt-gdb-adapter `#210`](https://github.com/eclipse-cdt-cloud/cdt-gdb-vscode/issues/210): Support value formatting for single expressions
 - Implements [cdt-gdb-adapter `#224`](https://github.com/eclipse-cdt-cloud/cdt-gdb-vscode/pull/224): Add highlighting of source code lines with machine code
 - Fixes [cdt-gdb-adapter `#218`](https://github.com/eclipse-cdt-cloud/cdt-gdb-vscode/issues/218): Race condition when using breakpoint modes to set HW/SW breaks
-- Update to cdt-gdb-adapter [v1.9.0](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/releases/tag/v1.9.0)
+- Update to cdt-gdb-adapter [v1.9.0](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/releases/tag/v1.9.0). 
+    - Skipped v1.8.0 and v1.8.1
     - Implements [`#527`](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/issues/527): Support setting expression values
     - Implements [`#506`](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/pull/506): Support value formatting in expressions with `,<type>` (where `<type>` is one of `x` (hex), `d` (dec), `o` (oct), `t`/`b` (bin), `z` (zero-padded hex)).
     - Fixes [`#507`](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/pull/507): Execution of GDB commands with quotes or backslashes (e.g. Windows paths) in the Debug Console. If you have previously added inexplicable extra backslashes to commands to work around this, you need to stop doing that now.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Implements [cdt-gdb-adapter `#210`](https://github.com/eclipse-cdt-cloud/cdt-gdb-vscode/issues/210): Support value formatting for single expressions
 - Implements [cdt-gdb-adapter `#224`](https://github.com/eclipse-cdt-cloud/cdt-gdb-vscode/pull/224): Add highlighting of source code lines with machine code
 - Fixes [cdt-gdb-adapter `#218`](https://github.com/eclipse-cdt-cloud/cdt-gdb-vscode/issues/218): Race condition when using breakpoint modes to set HW/SW breaks
-- Update to cdt-gdb-adapter [v1.9.0](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/releases/tag/v1.9.0). 
+- Update to cdt-gdb-adapter [v1.9.0](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/releases/tag/v1.9.0).
     - Skipped v1.8.0 and v1.8.1
     - Implements [`#527`](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/issues/527): Support setting expression values
     - Implements [`#506`](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/pull/506): Support value formatting in expressions with `,<type>` (where `<type>` is one of `x` (hex), `d` (dec), `o` (oct), `t`/`b` (bin), `z` (zero-padded hex)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,13 @@
 - Implements [cdt-gdb-adapter `#201`](https://github.com/eclipse-cdt-cloud/cdt-gdb-vscode/issues/201): Add a command that allow users to change GDB session radix
 - Implements [cdt-gdb-adapter `#206`](https://github.com/eclipse-cdt-cloud/cdt-gdb-vscode/issues/206): Add "Set Output Radix" commands to context menus
 - Implements [cdt-gdb-adapter `#210`](https://github.com/eclipse-cdt-cloud/cdt-gdb-vscode/issues/210): Support value formatting for single expressions
-- Implements [cdt-gdb-adapter `#224`](https://github.com/eclipse-cdt-cloud/cdt-gdb-vscode/pull/224): Add source code highlighting
+- Implements [cdt-gdb-adapter `#224`](https://github.com/eclipse-cdt-cloud/cdt-gdb-vscode/pull/224): Add highlighting of source code lines with machine code
 - Fixes [cdt-gdb-adapter `#218`](https://github.com/eclipse-cdt-cloud/cdt-gdb-vscode/issues/218): Race condition when using breakpoint modes to set HW/SW breaks
 - Update to cdt-gdb-adapter [v1.9.0](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/releases/tag/v1.9.0)
     - Implements [`#527`](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/issues/527): Support setting expression values
+    - Implements [`#506`](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/pull/506): Support value formatting in expressions with `,<type>` (where `<type>` is one of `x` (hex), `d` (dec), `o` (oct), `t`/`b` (bin), `z` (zero-padded hex)).
+    - Fixes [`#507`](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/pull/507): Execution of GDB commands with quotes or backslashes (e.g. Windows paths) in the Debug Console. If you have previously added inexplicable extra backslashes to commands to work around this, you need to stop doing that now.
+    - Fixes [`#516`](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/pull/516): Make sure error response is sent on failed setInstructionBreakpointsRequest.
 
 ## 2.7.0
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cdt-gdb-vscode",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "displayName": "CDT GDB Debug Adapter Extension",
   "description": "CDT GDB debug adapter extension for Visual Studio Code",
   "publisher": "eclipse-cdt",


### PR DESCRIPTION
- Implements [cdt-gdb-adapter `#201`](https://github.com/eclipse-cdt-cloud/cdt-gdb-vscode/issues/201): Add a command that allow users to change GDB session radix
- Implements [cdt-gdb-adapter `#206`](https://github.com/eclipse-cdt-cloud/cdt-gdb-vscode/issues/206): Add "Set Output Radix" commands to context menus
- Implements [cdt-gdb-adapter `#210`](https://github.com/eclipse-cdt-cloud/cdt-gdb-vscode/issues/210): Support value formatting for single expressions
- Implements [cdt-gdb-adapter `#224`](https://github.com/eclipse-cdt-cloud/cdt-gdb-vscode/pull/224): Add source code highlighting
- Fixes [cdt-gdb-adapter `#218`](https://github.com/eclipse-cdt-cloud/cdt-gdb-vscode/issues/218): Race condition when using breakpoint modes to set HW/SW breaks
- Update to cdt-gdb-adapter [v1.9.0](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/releases/tag/v1.9.0)
    - Implements [`#527`](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/issues/527): Support setting expression values