### PR TITLE
Fix version to 2.9.0 for re-publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cdt-gdb-vscode",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "displayName": "CDT GDB Debug Adapter Extension",
   "description": "CDT GDB debug adapter extension for Visual Studio Code",
   "publisher": "eclipse-cdt",


### PR DESCRIPTION
As the title says, skipping code review to get the fix republished ASAP.
This must have gotten lost when merging in `main` before merging it itself.