### PR TITLE
Don't update setting when session is closing

### DIFF
--- a/src/SourceFileHighlighting.ts
+++ b/src/SourceFileHighlighting.ts
@@ -199,29 +199,20 @@ export class SourceFileHighlighting {
             return;
         }
         this.activeDebugSession = session;
-        await this.handleOnDidChangeActiveTextEditor(
-            vscode.window.activeTextEditor
-        );
+        const shouldEnable = vscode.workspace
+            .getConfiguration()
+            .get<boolean>('cdt.debug.sourceHighlighting', true);
+        if (shouldEnable) {
+            await this.handleEnableSourceFileHighlighting();
+        } else {
+            return;
+        }
     }
 
     private async handleSessionInActive() {
         await this.clearExecutableLineDecorations(
             vscode.window.visibleTextEditors
         );
-        await vscode.commands.executeCommand(
-            'setContext',
-            'cdt.debug.sourceCodeHighlightingEnabled',
-            false
-        );
-        await vscode.workspace
-            .getConfiguration()
-            .update(
-                'cdt.debug.sourceHighlighting',
-                false,
-                vscode.ConfigurationTarget.Workspace
-            );
-        this.highlightingEnabled = false;
-        this.activeDebugSession = undefined;
         return;
     }
 

--- a/src/SourceFileHighlighting.ts
+++ b/src/SourceFileHighlighting.ts
@@ -199,14 +199,14 @@ export class SourceFileHighlighting {
             return;
         }
         this.activeDebugSession = session;
-        const shouldEnable = vscode.workspace
-            .getConfiguration()
-            .get<boolean>('cdt.debug.sourceHighlighting', true);
-        if (shouldEnable) {
-            await this.handleEnableSourceFileHighlighting();
-        } else {
-            return;
-        }
+        vscode.commands.executeCommand(
+            'setContext',
+            'cdt.debug.sourceCodeHighlightingEnabled',
+            this.highlightingEnabled
+        );
+        await this.handleOnDidChangeActiveTextEditor(
+            vscode.window.activeTextEditor
+        );
     }
 
     private async handleSessionInActive() {


### PR DESCRIPTION
when a debug session is shutting down, settings.json should not be updated again. Instead, the latest setting should remain as is

Fixes: https://github.com/eclipse-cdt-cloud/cdt-gdb-vscode/issues/243 and https://github.com/eclipse-cdt-cloud/cdt-gdb-vscode/issues/244
